### PR TITLE
修复 test-case.js 测试 bug

### DIFF
--- a/test-case.js
+++ b/test-case.js
@@ -1,3 +1,5 @@
+const viewLog = false //出现问题，设置为true可追踪函数和输出
+
 module.exports = compose => {
     it('同步函数', async () => {
         const mockFn = jest.fn()
@@ -14,14 +16,26 @@ module.exports = compose => {
                 mockFn('2 end')
             }
         ]
-        compose(middlewares)()
+        const func = compose(middlewares)
 
+        viewLog && console.log('同步函数 > compose定义', compose.toString());
+
+        func();
         const calls = mockFn.mock.calls
+        viewLog && console.log('第一次', calls);
         expect(calls.length).toBe(4);
         expect(calls[0][0]).toBe('1 start');
         expect(calls[1][0]).toBe('2 start');
         expect(calls[2][0]).toBe('2 end');
         expect(calls[3][0]).toBe('1 end');
+
+        func();
+        viewLog && console.log('第二次', calls);
+        expect(calls.length).toBe(8);
+        expect(calls[4][0]).toBe('1 start');
+        expect(calls[5][0]).toBe('2 start');
+        expect(calls[6][0]).toBe('2 end');
+        expect(calls[7][0]).toBe('1 end');
     })
 
     it('异步函数', async () => {
@@ -40,14 +54,27 @@ module.exports = compose => {
                 mockFn('2 end')
             }
         ]
-        await compose(middlewares)()
 
+        const func = compose(middlewares)
+
+        viewLog && console.log('异步函数 > compose定义', compose.toString());
+
+        await func();
         const calls = mockFn.mock.calls
+        viewLog && console.log('第一次', calls);
         expect(calls.length).toBe(4);
         expect(calls[0][0]).toBe('1 start');
         expect(calls[1][0]).toBe('2 start');
         expect(calls[2][0]).toBe('2 end');
         expect(calls[3][0]).toBe('1 end');
+
+        await func();
+        viewLog && console.log('第二次', calls);
+        expect(calls.length).toBe(8);
+        expect(calls[4][0]).toBe('1 start');
+        expect(calls[5][0]).toBe('2 start');
+        expect(calls[6][0]).toBe('2 end');
+        expect(calls[7][0]).toBe('1 end');
     })
     it('0个函数', async () => {
         const mockFn = jest.fn()


### PR DESCRIPTION
## 最新更新

之前提交的PR已经被合并，现在测试代码可以通过了

##  ~~_写在前面_~~

~~_测试失败不是 因为更新后 test-case.js 的问题，是之前 **Express 实现**、**Koa reduce实现** 存在bug导致，之前的 test-case.js 这种bug查不出来_~~

~~_先合并 下面 两个 PR 后，再执行 jest 测试 就可以通过了_~~

~~_[修复 koa-reduce.js 的二次调用bug](https://github.com/su37josephxia/compose-awesome/pull/20)_~~

~~_ [修复 express版本 二次调用bug](https://github.com/su37josephxia/compose-awesome/pull/18)_~~

## bug修复

如下代码：
```javascript
const test = require('../test-case')

const compose = (middlewares) => {
    const next = async () => {
        if (middlewares.length > 0) {
            return await middlewares.shift()(next);
        }
    };
    return () => next();
};

test(compose);
```
以上代码，用之前的test-case脚本是可以通过测试的：

![bug](https://user-images.githubusercontent.com/3360397/90950369-39375e00-e483-11ea-8074-dee6e6830f14.png)

但是程序时存在问题的， 比如用以下代码测试中间件，之前的程序测试通过，实际compose是有问题的：

```javascript
const mockFn = console.log

const compose = (middlewares) => {
  const next = async () => {
      if (middlewares.length > 0) {
          return await middlewares.shift()(next);
      }
  };
  return () => next();
};

const middlewares = [
  next => {
      mockFn('1 start')
      next()
      mockFn('1 end')
  },
  next => {
      mockFn('2 start')
      next()
      mockFn('2 end')
  }
]

const fn = compose(middlewares)

fn();
/**
 * 看来买没啥问题
 * 1 start
 * 2 start
 * 2 end
 * 1 end
 */

fn();
/**
 * 再来一遍，出问题了
 * Promise {<fulfilled>: undefined}
 */
```

修复也很简单，执行两遍后的测试，可以监测出来bug：

![fixed](https://user-images.githubusercontent.com/3360397/90950371-3dfc1200-e483-11ea-8c91-4ffa75abfc7e.png)


## 代码改进

现在compse 版本有点多，出现bug时不好排查原因。

增加了 viewLog 开关，如果 设置为 true时，可以排查时哪个 compse函数出现的问题

![console](https://user-images.githubusercontent.com/3360397/90950365-2886e800-e483-11ea-813b-65aa864cd944.png)

